### PR TITLE
fix - Missing "@Input()" in example

### DIFF
--- a/angular/interaction-entre-composants/input.md
+++ b/angular/interaction-entre-composants/input.md
@@ -117,7 +117,7 @@ export AppComponent {
 ```typescript
 ...
 export class BookPreviewComponent {
-    book: Book;
+    @Input() book: Book;
 }
 ```
 {% endtab %}


### PR DESCRIPTION
In the corrected example, the `@Input()` is still missing